### PR TITLE
Fix device mismatch bug on GPU for RNN, LSTM, GRU, Transformer and generate script

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -23,7 +23,8 @@ def generate_text(model, max_len=10000, delay=0.025):
     token_to_idx, idx_to_token = model.tokenizer
 
     # Initialize input
-    input = torch.tensor([token_to_idx["\n"]], dtype=torch.long).view(1, 1)
+    device = next(model.parameters()).device
+    input = torch.tensor([token_to_idx["\n"]], dtype=torch.long, device=device).view(1, 1)
 
     for _ in range(max_len):
         # Generate next token

--- a/models/gru.py
+++ b/models/gru.py
@@ -29,8 +29,9 @@ class GRU(BaseModule):
 
     def forward(self, x):
         B, T = x.shape
-        a = torch.zeros(B, self.hidden_dim)
-        logits = torch.empty(B, T, self.vocab_size)
+        device = x.device
+        a = torch.zeros(B, self.hidden_dim, device=device)
+        logits = torch.empty(B, T, self.vocab_size, device=device)
         for t in range(T):
             x_t = x[:, t]
             x_t = self.tok_embedding(x_t)

--- a/models/lstm.py
+++ b/models/lstm.py
@@ -32,9 +32,10 @@ class LSTM(BaseModule):
 
     def forward(self, x):
         B, T = x.shape
-        a = torch.zeros(B, self.hidden_dim)
-        c = torch.zeros(B, self.hidden_dim)
-        logits = torch.empty(B, T, self.vocab_size)
+        device = x.device
+        a = torch.zeros(B, self.hidden_dim, device=device)
+        c = torch.zeros(B, self.hidden_dim, device=device)
+        logits = torch.empty(B, T, self.vocab_size, device=device)
         for t in range(T):
             x_t = x[:, t]
             x_t = self.tok_embedding(x_t)

--- a/models/rnn.py
+++ b/models/rnn.py
@@ -22,8 +22,9 @@ class RNN(BaseModule):
 
     def forward(self, x):
         B, T = x.shape
-        a = torch.zeros(B, self.hidden_dim)
-        logits = torch.empty(B, T, self.vocab_size)
+        device = x.device
+        a = torch.zeros(B, self.hidden_dim, device=device)
+        logits = torch.empty(B, T, self.vocab_size, device=device)
         for t in range(T):
             x_t = x[:, t]
             x_t = self.tok_embedding(x_t)

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -33,7 +33,9 @@ class Transformer(BaseModule):
 
     def forward(self, x):
         B, T = x.shape
-        x = self.tok_embedding(x) + self.pos_embedding(torch.arange(T))
+        device = x.device
+        positions = torch.arange(T, device=device)
+        x = self.tok_embedding(x) + self.pos_embedding(positions)
         x = self.encoders(x)
         logits = self.fc(x)
         return logits


### PR DESCRIPTION
Ensure hidden states, logits, positional embeddings and the initial input are instantiated on the same device as the input/model to avoid CPU/GPU device mismatch errors.